### PR TITLE
Fixed Laser Cutter Requirements

### DIFF
--- a/locations/Crater.json
+++ b/locations/Crater.json
@@ -521,7 +521,7 @@
                         "name": "Hangar Databox",
                         "access_rules":
                         [
-                            "[$canAccess|698.2|-350.8|1186.9], $canAccess|698.2|-350.8|1186.9cutter:3
+                            "[$canAccess|698.2|-350.8|1186.9], $canAccess|698.2|-350.8|1186.9|5, cutter:3"
                         ],
                         "item_count": 1
                     },
@@ -529,7 +529,7 @@
                         "name": "Data Terminal",
                         "access_rules":
                         [
-                            "[$canAccess|703.7|-365.9|1199.3], $canAccess|703.7|-365.9|1199.3cutter:3
+                            "[$canAccess|703.7|-365.9|1199.3], $canAccess|703.7|-365.9|1199.3|5, cutter:3"
                         ],
                         "item_count": 1
                     }
@@ -589,7 +589,7 @@
                         "name": "Cargo Databox",
                         "access_rules": 
                         [
-                            "[$canAccess|-655.1|-109.6|791.0], $canAccess|-655.1|-109.6|791.0cutter:3
+                            "[$canAccess|-655.1|-109.6|791.0], $canAccess|-655.1|-109.6|791.0|5, cutter:3"
                         ],
                         "item_count": 1
                     },
@@ -635,7 +635,7 @@
                         "name": "Hangar Databox",
                         "access_rules": 
                         [ 
-                            "[$canAccess|-1129.5|-155.2|-729.3], $canAccess|-1129.5|-155.2|-729.3cutter:3
+                            "[$canAccess|-1129.5|-155.2|-729.3], $canAccess|-1129.5|-155.2|-729.3|5, cutter:3"
                         ],
                         "item_count": 1
                     },
@@ -711,7 +711,7 @@
                         "name": "Hangar Databox",
                         "access_rules": 
                         [
-                            "[$canAccess|-138.4|-193.6|888.7], $canAccess|-138.4|-193.6|888.7cutter:3
+                            "[$canAccess|-138.4|-193.6|888.7], $canAccess|-138.4|-193.6|888.7|5, cutter:3"
                         ],
                         "item_count": 1
                     },
@@ -745,7 +745,7 @@
                         "name": "Data Terminal",
                         "access_rules": 
                         [
-                            "[$canAccess|-130.7|-193.2|883.3], $canAccess|-130.7|-193.2|883.3cutter:3
+                            "[$canAccess|-130.7|-193.2|883.3], $canAccess|-130.7|-193.2|883.3|5, cutter:3"
                         ],
                         "item_count": 1
                     }

--- a/locations/Crater.json
+++ b/locations/Crater.json
@@ -349,7 +349,7 @@
                         "name": "Breach Databox",
                         "access_rules": 
                         [
-                            "[$canAccess|313.9|-91.8|432.6], $canAccess|313.9|-91.8|432.6|5, [cutter:3]"
+                            "[$canAccess|313.9|-91.8|432.6], $canAccess|313.9|-91.8|432.6|5, cutter:3"
                         ],  
                         "item_count": 1
                     },
@@ -357,7 +357,7 @@
                         "name": "Hangar Databox",
                         "access_rules":
                         [                         
-                            "[$canAccess|319.4|-104.3|441.5], $canAccess|319.4|-104.3|441.5|5, [cutter:3]"
+                            "[$canAccess|319.4|-104.3|441.5], $canAccess|319.4|-104.3|441.5|5, cutter:3"
                         ],
                         "item_count": 1
                     }
@@ -417,7 +417,7 @@
                         "name": "Databox",
                         "access_rules": 
                         [
-                            "[$canAccess|-421.4|-107.8|-266.5], $canAccess|-421.4|-107.8|-266.5|5, cutter:3"
+                            "[$canAccess|-421.4|-107.8|-266.5], $canAccess|-421.4|-107.8|-266.5|5, "
                         ],
                         "item_count": 1
                     }
@@ -521,7 +521,7 @@
                         "name": "Hangar Databox",
                         "access_rules":
                         [
-                            "[$canAccess|698.2|-350.8|1186.9], $canAccess|698.2|-350.8|1186.9|5, cutter:3"
+                            "[$canAccess|698.2|-350.8|1186.9], $canAccess|698.2|-350.8|1186.9|5, "
                         ],
                         "item_count": 1
                     },
@@ -529,7 +529,7 @@
                         "name": "Data Terminal",
                         "access_rules":
                         [
-                            "[$canAccess|703.7|-365.9|1199.3], $canAccess|703.7|-365.9|1199.3|5, cutter:3"
+                            "[$canAccess|703.7|-365.9|1199.3], $canAccess|703.7|-365.9|1199.3|5, "
                         ],
                         "item_count": 1
                     }
@@ -589,7 +589,7 @@
                         "name": "Cargo Databox",
                         "access_rules": 
                         [
-                            "[$canAccess|-655.1|-109.6|791.0], $canAccess|-655.1|-109.6|791.0|5, cutter:3"
+                            "[$canAccess|-655.1|-109.6|791.0], $canAccess|-655.1|-109.6|791.0|5, "
                         ],
                         "item_count": 1
                     },
@@ -635,7 +635,7 @@
                         "name": "Hangar Databox",
                         "access_rules": 
                         [ 
-                            "[$canAccess|-1129.5|-155.2|-729.3], $canAccess|-1129.5|-155.2|-729.3|5, cutter:3"
+                            "[$canAccess|-1129.5|-155.2|-729.3], $canAccess|-1129.5|-155.2|-729.3|5, "
                         ],
                         "item_count": 1
                     },
@@ -681,7 +681,7 @@
                         "name": "Lab Databox",
                         "access_rules": 
                         [
-                            "[$canAccess|-795.5|-204.1|-774.7], $canAccess|-795.5|-204.1|-774.7|5, cutter:3"
+                            "[$canAccess|-795.5|-204.1|-774.7], $canAccess|-795.5|-204.1|-774.7|5, "
                         ],
                         "item_count": 1
                     }
@@ -711,7 +711,7 @@
                         "name": "Hangar Databox",
                         "access_rules": 
                         [
-                            "[$canAccess|-138.4|-193.6|888.7], $canAccess|-138.4|-193.6|888.7|5, cutter:3"
+                            "[$canAccess|-138.4|-193.6|888.7], $canAccess|-138.4|-193.6|888.7|5, "
                         ],
                         "item_count": 1
                     },
@@ -745,7 +745,7 @@
                         "name": "Data Terminal",
                         "access_rules": 
                         [
-                            "[$canAccess|-130.7|-193.2|883.3], $canAccess|-130.7|-193.2|883.3|5, cutter:3"
+                            "[$canAccess|-130.7|-193.2|883.3], $canAccess|-130.7|-193.2|883.3|5, "
                         ],
                         "item_count": 1
                     }

--- a/locations/Crater.json
+++ b/locations/Crater.json
@@ -673,7 +673,7 @@
                         "name": "Locker Databox",
                         "access_rules": 
                         [
-                            "[$canAccess|-789.8|-216.1|-711.0], $canAccess|-789.8|-216.1|-711.0|5"
+                            "[$canAccess|-789.8|-216.1|-711.0], $canAccess|-789.8|-216.1|-711.0|5, cutter:3"
                         ],
                         "item_count": 1
                     },  
@@ -681,7 +681,7 @@
                         "name": "Lab Databox",
                         "access_rules": 
                         [
-                            "[$canAccess|-795.5|-204.1|-774.7], $canAccess|-795.5|-204.1|-774.7|5, "
+                            "[$canAccess|-795.5|-204.1|-774.7], $canAccess|-795.5|-204.1|-774.7|5, cutter:3"
                         ],
                         "item_count": 1
                     }

--- a/locations/Crater.json
+++ b/locations/Crater.json
@@ -417,7 +417,7 @@
                         "name": "Databox",
                         "access_rules": 
                         [
-                            "[$canAccess|-421.4|-107.8|-266.5], $canAccess|-421.4|-107.8|-266.5|5, "
+                            "[$canAccess|-421.4|-107.8|-266.5], $canAccess|-421.4|-107.8|-266.5|5, cutter:3"
                         ],
                         "item_count": 1
                     }
@@ -521,7 +521,7 @@
                         "name": "Hangar Databox",
                         "access_rules":
                         [
-                            "[$canAccess|698.2|-350.8|1186.9], $canAccess|698.2|-350.8|1186.9|5, "
+                            "[$canAccess|698.2|-350.8|1186.9], $canAccess|698.2|-350.8|1186.9cutter:3
                         ],
                         "item_count": 1
                     },
@@ -529,7 +529,7 @@
                         "name": "Data Terminal",
                         "access_rules":
                         [
-                            "[$canAccess|703.7|-365.9|1199.3], $canAccess|703.7|-365.9|1199.3|5, "
+                            "[$canAccess|703.7|-365.9|1199.3], $canAccess|703.7|-365.9|1199.3cutter:3
                         ],
                         "item_count": 1
                     }
@@ -589,7 +589,7 @@
                         "name": "Cargo Databox",
                         "access_rules": 
                         [
-                            "[$canAccess|-655.1|-109.6|791.0], $canAccess|-655.1|-109.6|791.0|5, "
+                            "[$canAccess|-655.1|-109.6|791.0], $canAccess|-655.1|-109.6|791.0cutter:3
                         ],
                         "item_count": 1
                     },
@@ -635,7 +635,7 @@
                         "name": "Hangar Databox",
                         "access_rules": 
                         [ 
-                            "[$canAccess|-1129.5|-155.2|-729.3], $canAccess|-1129.5|-155.2|-729.3|5, "
+                            "[$canAccess|-1129.5|-155.2|-729.3], $canAccess|-1129.5|-155.2|-729.3cutter:3
                         ],
                         "item_count": 1
                     },
@@ -711,7 +711,7 @@
                         "name": "Hangar Databox",
                         "access_rules": 
                         [
-                            "[$canAccess|-138.4|-193.6|888.7], $canAccess|-138.4|-193.6|888.7|5, "
+                            "[$canAccess|-138.4|-193.6|888.7], $canAccess|-138.4|-193.6|888.7cutter:3
                         ],
                         "item_count": 1
                     },
@@ -745,7 +745,7 @@
                         "name": "Data Terminal",
                         "access_rules": 
                         [
-                            "[$canAccess|-130.7|-193.2|883.3], $canAccess|-130.7|-193.2|883.3|5, "
+                            "[$canAccess|-130.7|-193.2|883.3], $canAccess|-130.7|-193.2|883.3cutter:3
                         ],
                         "item_count": 1
                     }


### PR DESCRIPTION
Fixed the Laser Cutter 3 requirement of "Grassy Plateaus East Wreck" and "Spares Reef Wreck".
![image](https://github.com/user-attachments/assets/7375c521-09a4-4597-b664-3b2a7a8844db)
![image](https://github.com/user-attachments/assets/36681268-68a0-4fe2-bca2-4733acee3d60)

These is also not shown by the in-game tracker as being accessible, only PopTracker shows them.